### PR TITLE
fix: align autosave interval units across options and validation

### DIFF
--- a/tests/game-options-schema.test.ts
+++ b/tests/game-options-schema.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { defaultState } from '../ts/core/state/shape';
+import { GameOptionsSchema } from '../ts/core/validation/schemas';
+
+describe('GameOptionsSchema', () => {
+  it('accepts default options from state shape', () => {
+    const parsed = GameOptionsSchema.parse(defaultState.options);
+    expect(parsed).toEqual(defaultState.options);
+  });
+});

--- a/ts/core/systems/options-system.ts
+++ b/ts/core/systems/options-system.ts
@@ -6,7 +6,7 @@ const OPTIONS_KEY = 'gameOptions';
 
 export type GameOptions = {
   autosaveEnabled: boolean;
-  autosaveInterval: number; // ms
+  autosaveInterval: number; // seconds
   clickSoundsEnabled: boolean;
   musicEnabled: boolean;
   musicStreamPreferences?: any;

--- a/ts/core/validation/schemas.ts
+++ b/ts/core/validation/schemas.ts
@@ -163,17 +163,25 @@ export type GameOptions = {
   autosaveInterval: number;
   clickSoundsEnabled: boolean;
   musicEnabled: boolean;
-  musicStreamPreferences?: Record<string, boolean>;
+  musicStreamPreferences?: {
+    preferred: string;
+    fallbacks: string[];
+  };
   devToolsEnabled: boolean;
   secretsUnlocked: boolean;
   godTabEnabled: boolean;
 };
 export const GameOptionsSchema = z.object({
   autosaveEnabled: z.boolean(),
-  autosaveInterval: z.number().min(1000).max(60000),
+  autosaveInterval: z.number().min(1).max(60),
   clickSoundsEnabled: z.boolean(),
   musicEnabled: z.boolean(),
-  musicStreamPreferences: z.record(z.string(), z.boolean()).optional(),
+  musicStreamPreferences: z
+    .object({
+      preferred: z.string(),
+      fallbacks: z.array(z.string()),
+    })
+    .optional(),
   devToolsEnabled: z.boolean(),
   secretsUnlocked: z.boolean(),
   godTabEnabled: z.boolean(),


### PR DESCRIPTION
### Motivation
- The codebase treats `autosaveInterval` as seconds in runtime/defaults, but validation and some types implied milliseconds; this caused potential mismatch between UI, options persistence, and autosave logic.
- The default `musicStreamPreferences` shape in state did not match the schema, causing validation failures for default options.

### Description
- Updated `GameOptionsSchema.autosaveInterval` bounds from `min(1000).max(60000)` to `min(1).max(60)` to validate seconds instead of millisecond-like values (`ts/core/validation/schemas.ts`).
- Made `musicStreamPreferences` schema match the default state shape (`preferred: string` and `fallbacks: string[]`) so defaults validate cleanly (`ts/core/validation/schemas.ts`).
- Clarified the `autosaveInterval` unit comment to `// seconds` in the options type (`ts/core/systems/options-system.ts`).
- Added a focused test `tests/game-options-schema.test.ts` that asserts `defaultState.options` passes `GameOptionsSchema`, and verified UI/autosave code paths use seconds (inspected `ts/ui/displays.ts` and `ts/core/systems/autosave.ts`).

### Testing
- Ran the new unit test with `npm run test -- tests/game-options-schema.test.ts` and it passed.
- Ran TypeScript checks with `npm run type-check` and it passed.
- Pre-commit checks including `eslint` and `prettier` formatting checks were executed during commit and passed (lint shows unrelated warnings in script files only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d803b8408330a7240d074f3ca467)